### PR TITLE
feat: Add CI/CD workflow for Java project

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,23 @@
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn clean install
+      - name: Run tests
+        run: mvn test


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow for the Java
project. The workflow is triggered on both push and pull request
events targeting the main branch. It sets up the required Java
environment, builds the project using Maven, and runs the test suite.
This ensures that the codebase is continually tested and integrated,
improving the overall project quality and reliability.