### PR TITLE
feat: add code coverage reporting to CI/CD pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -19,5 +19,9 @@ jobs:
           distribution: 'adopt'
       - name: Build with Maven
         run: mvn clean install
-      - name: Run tests
-        run: mvn test
+      - name: Run tests and generate coverage report
+        run: mvn test jacoco:report
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+            fail_ci_if_error: true


### PR DESCRIPTION
The changes in this commit add code coverage reporting to the CI/CD pipeline using
the Jacoco Maven plugin and the Codecov GitHub Action. This will provide better
visibility into the test coverage of the application and help identify areas that
need more testing.