### PR TITLE
feat(pom.xml): Add JaCoCo code coverage plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,25 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.7</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Adds the JaCoCo code coverage plugin to the Maven build configuration.
This will generate a code coverage report during the build process,
which can be used to monitor and improve the test coverage of the
application.