### PR TITLE
feat(ci-cd): Archive code coverage report instead of uploading to Codecov

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,7 +21,8 @@ jobs:
         run: mvn clean install
       - name: Run tests and generate coverage report
         run: mvn test jacoco:report
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+      - name: Archive code coverage results
+        uses: actions/upload-artifact@v3
         with:
-            fail_ci_if_error: true
+          name: code-coverage-report
+          path: target/site/jacoco/


### PR DESCRIPTION
Instead of uploading the code coverage report directly to Codecov, this change
archives the report as an artifact. This allows the report to be accessed and
analyzed later, without the risk of failing the CI/CD pipeline if there is an
issue with the Codecov upload.