### PR TITLE
feat: Archive test results in CI/CD workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -26,3 +26,10 @@ jobs:
         with:
           name: code-coverage-report
           path: target/site/jacoco/
+      - name: Archive test results
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-results
+          path: |
+            target/surefire-reports/
+            target/karate-reports/


### PR DESCRIPTION
This change adds the ability to archive test results as artifacts
in the CI/CD workflow. The test results from the surefire and
karate reports are now being uploaded as artifacts, which can
be accessed and analyzed later in the workflow or by developers.